### PR TITLE
Fix octal printing in mdb-export

### DIFF
--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -64,7 +64,7 @@ print_col(FILE *outfile, gchar *col_val, int quote_text, int col_type, int bin_l
 				fprintf(outfile, "%s%s", escape_char, escape_char);
 				col_val += orig_escape_len;
 #endif
-			} else if (is_binary_type(col_type) && *col_val <= 0 && bin_mode == MDB_BINEXPORT_OCTAL)
+			} else if (is_binary_type(col_type) && bin_mode == MDB_BINEXPORT_OCTAL)
 				fprintf(outfile, "\\%03o", *(unsigned char*)col_val++);
 			else
 				putc(*col_val++, outfile);


### PR DESCRIPTION
Removes an expression from `mdb-export` that was causing some bytes to be printed raw instead of octal